### PR TITLE
Doc: This patch will fix spelling mistake from file listed below.

### DIFF
--- a/sha256block_arm64.s
+++ b/sha256block_arm64.s
@@ -19,7 +19,7 @@
 //
 
 //
-// Based on implementaion as found in  https://github.com/jocover/sha256-armv8
+// Based on implementation as found in  https://github.com/jocover/sha256-armv8
 //
 // Use github.com/minio/asm2plan9s on this file to assemble ARM instructions to
 // their Plan9 equivalents


### PR DESCRIPTION
	modified:   sha256block_arm64.s
