### PR TITLE
Build on ppc64/ppc64le

### DIFF
--- a/cpuid_ppc64.go
+++ b/cpuid_ppc64.go
@@ -1,0 +1,32 @@
+// Minio Cloud Storage, (C) 2016 Minio, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package sha256
+
+func cpuid(op uint32) (eax, ebx, ecx, edx uint32) {
+	return 0, 0, 0, 0
+}
+
+func cpuidex(op, op2 uint32) (eax, ebx, ecx, edx uint32) {
+	return 0, 0, 0, 0
+}
+
+func xgetbv(index uint32) (eax, edx uint32) {
+	return 0, 0
+}
+
+func haveArmSha() bool {
+	return false
+}

--- a/cpuid_ppc64le.go
+++ b/cpuid_ppc64le.go
@@ -1,0 +1,32 @@
+// Minio Cloud Storage, (C) 2016 Minio, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package sha256
+
+func cpuid(op uint32) (eax, ebx, ecx, edx uint32) {
+	return 0, 0, 0, 0
+}
+
+func cpuidex(op, op2 uint32) (eax, ebx, ecx, edx uint32) {
+	return 0, 0, 0, 0
+}
+
+func xgetbv(index uint32) (eax, edx uint32) {
+	return 0, 0
+}
+
+func haveArmSha() bool {
+	return false
+}

--- a/sha256block_ppc64.go
+++ b/sha256block_ppc64.go
@@ -1,0 +1,22 @@
+/*
+ * Minio Cloud Storage, (C) 2016 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sha256
+
+func blockAvx2Go(dig *digest, p []byte) {}
+func blockAvxGo(dig *digest, p []byte)  {}
+func blockSsseGo(dig *digest, p []byte) {}
+func blockArmGo(dig *digest, p []byte)  {}

--- a/sha256block_ppc64le.go
+++ b/sha256block_ppc64le.go
@@ -1,0 +1,22 @@
+/*
+ * Minio Cloud Storage, (C) 2016 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sha256
+
+func blockAvx2Go(dig *digest, p []byte) {}
+func blockAvxGo(dig *digest, p []byte)  {}
+func blockSsseGo(dig *digest, p []byte) {}
+func blockArmGo(dig *digest, p []byte)  {}


### PR DESCRIPTION
I've followed the existing practice of having separate files per arch, even though it could have been done with build tags somewhere. Let me know if you want this cleaned up somehow.

I've verified that it *builds* on ppc64 and ppc64le, but not that it actually works as I don't have such a machine on hand. Please judge the risk that I may have screwed something up on that front. :)