### PR TITLE
Check for sha2 feature flag.

### DIFF
--- a/cpuid_linux_arm64.go
+++ b/cpuid_linux_arm64.go
@@ -1,3 +1,5 @@
+// +build arm64,linux
+
 // Minio Cloud Storage, (C) 2016 Minio, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,6 +17,11 @@
 
 package sha256
 
+import (
+	"bytes"
+	"io/ioutil"
+)
+
 func cpuid(op uint32) (eax, ebx, ecx, edx uint32) {
 	return 0, 0, 0, 0
 }
@@ -27,6 +34,16 @@ func xgetbv(index uint32) (eax, edx uint32) {
 	return 0, 0
 }
 
+// File to check for cpu capabilities.
+const procCPUInfo = "/proc/cpuinfo"
+
+// Feature to check for.
+const sha256Feature = "sha2"
+
 func haveArmSha() bool {
-	return false
+	cpuInfo, err := ioutil.ReadFile(procCPUInfo)
+	if err != nil {
+		return false
+	}
+	return bytes.Contains(cpuInfo, []byte(sha256Feature))
 }

--- a/cpuid_others_arm64.go
+++ b/cpuid_others_arm64.go
@@ -1,3 +1,5 @@
+// +build arm64,!linux
+
 // Minio Cloud Storage, (C) 2016 Minio, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -27,7 +29,7 @@ func xgetbv(index uint32) (eax, edx uint32) {
 	return 0, 0
 }
 
+// Check for sha2 instruction flag.
 func haveArmSha() bool {
-	// TODO: Implement feature detection for ARM
-	return true
+	return false
 }

--- a/sha256.go
+++ b/sha256.go
@@ -89,7 +89,8 @@ func New() hash.Hash {
 		d.Reset()
 		return d
 	}
-	// default back to the standard golang implementation
+	// Fallback to the standard golang implementation
+	// if no features were found.
 	return sha256.New()
 }
 


### PR DESCRIPTION
There is no easier way to get this information
other than employing `getauxval()` which requires
cgo dependency. Since once set this value is
constant we can use a simple technique by just
reading `/proc/cpuinfo` file.

This is only supported on Linux. Fixes #6 