### PR TITLE
Build on mips

### DIFF
--- a/cpuid_mips.go
+++ b/cpuid_mips.go
@@ -1,0 +1,32 @@
+// Minio Cloud Storage, (C) 2016 Minio, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package sha256
+
+func cpuid(op uint32) (eax, ebx, ecx, edx uint32) {
+	return 0, 0, 0, 0
+}
+
+func cpuidex(op, op2 uint32) (eax, ebx, ecx, edx uint32) {
+	return 0, 0, 0, 0
+}
+
+func xgetbv(index uint32) (eax, edx uint32) {
+	return 0, 0
+}
+
+func haveArmSha() bool {
+	return false
+}

--- a/sha256block_mips.go
+++ b/sha256block_mips.go
@@ -1,0 +1,22 @@
+/*
+ * Minio Cloud Storage, (C) 2016 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sha256
+
+func blockAvx2Go(dig *digest, p []byte) {}
+func blockAvxGo(dig *digest, p []byte)  {}
+func blockSsseGo(dig *digest, p []byte) {}
+func blockArmGo(dig *digest, p []byte)  {}


### PR DESCRIPTION
This is just a copy and paste job to get the required function signatures available for `GOARCH=mips`. 