### PR TITLE
README: "unrolled" AVX2 version by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,9 @@ Below is the speed in MB/s for a single core (ranked fast to slow) as well as th
 | 2.4 GHz Intel Xeon CPU E5-2620 v3 | crypto/sha256                |  189.2 MB/s |             |
 | 1.2 GHz ARM Cortex-A53            | crypto/sha256                |    6.1 MB/s |             |
 
-(*) Measured with the "unrolled"/"demacro-ed" AVX2 version. Due to some Golang assembly restrictions the AVX2 version that uses `defines` loses about 15% performance. The optimized version is contained in the git history so for maximum speed you want to do this after getting: `git cat-file blob 586b6e > sha256blockAvx2_amd64.s` (or vendor it for your project; see [here](https://github.com/minio/sha256-simd/blob/13b11bdf9b0580a756a111492d2ae382bab7ec79/sha256blockAvx2_amd64.s) to view it in its full glory).
+(*) Measured with the "unrolled"/"demacro-ed" AVX2 version. Due to some Golang assembly restrictions the AVX2 version that uses `defines` loses about 15% performance.
  
- See further down for detailed performance.
+See further down for detailed performance.
  
 ## Comparison to other hashing techniques
 


### PR DESCRIPTION
The "unrolled" version is committed by `6f50cd1d784b2bea46167b6929f16c0d12eefbfb`.

You can close this, or revert into "rolled" version.

May I ask there is any side effects with "unrolled" version? Thanks!