### PR TITLE
Add support for WASM

### DIFF
--- a/cpuid_other.go
+++ b/cpuid_other.go
@@ -13,7 +13,7 @@
 // limitations under the License.
 //
 
-// +build ppc64 ppc64le mips mipsle mips64 mips64le s390x
+// +build ppc64 ppc64le mips mipsle mips64 mips64le s390x wasm
 
 package sha256
 

--- a/sha256block_other.go
+++ b/sha256block_other.go
@@ -13,7 +13,7 @@
 // limitations under the License.
 //
 
-// +build ppc64 ppc64le mips mipsle mips64 mips64le s390x
+// +build ppc64 ppc64le mips mipsle mips64 mips64le s390x wasm
 
 package sha256
 


### PR DESCRIPTION
Go 1.11 adds support for web assembly. We need to add this to the `other` files.