### PR TITLE
Hash reader interface

### DIFF
--- a/sha256.go
+++ b/sha256.go
@@ -140,8 +140,15 @@ func (d *digest) Sum(in []byte) []byte {
 	return append(in, hash[:]...)
 }
 
-// Intermediate checksum function
-func (d *digest) checkSum() [Size]byte {
+// Reads sha256 sum to byte array
+func (d *digest) Read(out []byte) (int, error) {
+	// Make a copy of d0 so that caller can keep writing and summing.
+	d0 := *d
+	return d0.read(out)
+}
+
+// Reads sha256 sum to byte array
+func (d *digest) read(digest []byte) (int, error) {
 	len := d.len
 	// Padding.  Add a 1 bit and 0 bits until 56 bytes mod 64.
 	var tmp [64]byte
@@ -165,7 +172,6 @@ func (d *digest) checkSum() [Size]byte {
 
 	h := d.h[:]
 
-	var digest [Size]byte
 	for i, s := range h {
 		digest[i*4] = byte(s >> 24)
 		digest[i*4+1] = byte(s >> 16)
@@ -173,5 +179,11 @@ func (d *digest) checkSum() [Size]byte {
 		digest[i*4+3] = byte(s)
 	}
 
-	return digest
+	return Size, nil
+}
+
+// Intermediate checksum function
+func (d *digest) checkSum() (digest [Size]byte) {
+	d.read(digest[:])
+	return
 }

--- a/sha256_test.go
+++ b/sha256_test.go
@@ -52,6 +52,7 @@ package sha256
 import (
 	"encoding/hex"
 	"fmt"
+	"io"
 	"strings"
 	"testing"
 )
@@ -2268,3 +2269,10 @@ func BenchmarkHash8K(b *testing.B)      { benchmarkSize(b, 8192) }
 func BenchmarkHash1MAvx2(b *testing.B)  { benchmarkSize(b, 1024*1024) }
 func BenchmarkHash5MAvx2(b *testing.B)  { benchmarkSize(b, 5*1024*1024) }
 func BenchmarkHash10MAvx2(b *testing.B) { benchmarkSize(b, 10*1024*1024) }
+
+func TestReader(t *testing.T) {
+	c := New()
+	if _, ok := c.(io.Reader); !ok {
+		t.Fatal("Reader not implemented")
+	}
+}


### PR DESCRIPTION
Let's us cast to `io.Reader` and Read hash straight into a buffer.

It _will_ cause a runtime panic if `out` capacity is lower than `32`. I consider it better than error.