### PR TITLE
fixing noasm tag build

### DIFF
--- a/sha256.go
+++ b/sha256.go
@@ -77,22 +77,6 @@ const (
 
 var blockfunc blockfuncType
 
-func block(dig *digest, p []byte) {
-	if blockfunc == blockfuncSha {
-		blockShaGo(dig, p)
-	} else if blockfunc == blockfuncAvx2 {
-		blockAvx2Go(dig, p)
-	} else if blockfunc == blockfuncAvx {
-		blockAvxGo(dig, p)
-	} else if blockfunc == blockfuncSsse {
-		blockSsseGo(dig, p)
-	} else if blockfunc == blockfuncArm {
-		blockArmGo(dig, p)
-	} else if blockfunc == blockfuncGeneric {
-		blockGeneric(dig, p)
-	}
-}
-
 func init() {
 	is386bit := runtime.GOARCH == "386"
 	isARM := runtime.GOARCH == "arm"

--- a/sha256blockAvx2_amd64.s
+++ b/sha256blockAvx2_amd64.s
@@ -1,4 +1,4 @@
-//+build !noasm !appengine
+//+build !noasm,!appengine
 
 // SHA256 implementation for AVX2
 

--- a/sha256blockAvx512_amd64.s
+++ b/sha256blockAvx512_amd64.s
@@ -1,3 +1,5 @@
+//+build !noasm,!appengine
+
 TEXT ·sha256X16Avx512(SB), 7, $0
 	MOVQ  digests+0(FP), DI
 	MOVQ  scratch+8(FP), R12

--- a/sha256blockAvx_amd64.s
+++ b/sha256blockAvx_amd64.s
@@ -1,4 +1,4 @@
-//+build !noasm !appengine
+//+build !noasm,!appengine
 
 // SHA256 implementation for AVX
 

--- a/sha256blockSha_amd64.s
+++ b/sha256blockSha_amd64.s
@@ -1,4 +1,4 @@
-//+build !noasm !appengine
+//+build !noasm,!appengine
 
 // SHA intrinsic version of SHA256
 

--- a/sha256blockSsse_amd64.s
+++ b/sha256blockSsse_amd64.s
@@ -1,4 +1,4 @@
-//+build !noasm !appengine
+//+build !noasm,!appengine
 
 // SHA256 implementation for SSSE3
 

--- a/sha256block_noasm.go
+++ b/sha256block_noasm.go
@@ -18,6 +18,10 @@
 
 package sha256
 
+func block(dig *digest, p []byte) {
+	blockGeneric(dig, p)
+}
+
 func blockGeneric(dig *digest, p []byte) {
 	var w [64]uint32
 	h0, h1, h2, h3, h4, h5, h6, h7 := dig.h[0], dig.h[1], dig.h[2], dig.h[3], dig.h[4], dig.h[5], dig.h[6], dig.h[7]

--- a/sha256block_other.go
+++ b/sha256block_other.go
@@ -22,3 +22,19 @@ func blockAvxGo(dig *digest, p []byte)  {}
 func blockSsseGo(dig *digest, p []byte) {}
 func blockShaGo(dig *digest, p []byte)  {}
 func blockArmGo(dig *digest, p []byte)  {}
+
+func block(dig *digest, p []byte) {
+	if blockfunc == blockfuncSha {
+		blockShaGo(dig, p)
+	} else if blockfunc == blockfuncAvx2 {
+		blockAvx2Go(dig, p)
+	} else if blockfunc == blockfuncAvx {
+		blockAvxGo(dig, p)
+	} else if blockfunc == blockfuncSsse {
+		blockSsseGo(dig, p)
+	} else if blockfunc == blockfuncArm {
+		blockArmGo(dig, p)
+	} else if blockfunc == blockfuncGeneric {
+		blockGeneric(dig, p)
+	}
+}


### PR DESCRIPTION
I am working on a project that requires me to build without assembly. This pull request adds the option of building with the `-tags noasm` flag.