### PR TITLE
fix noasm test

### DIFF
--- a/sha256blockAvx512_amd64_test.go
+++ b/sha256blockAvx512_amd64_test.go
@@ -1,3 +1,5 @@
+//+build !noasm
+
 /*
  * Minio Cloud Storage, (C) 2017 Minio, Inc.
  *


### PR DESCRIPTION
Ignores a test that should not be run with the `noasm` tag.