### PR TITLE
go.mod: upgrade github.com/klauspost/cpuid/v2@v2.0.6 for darwin AVX512

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/minio/sha256-simd
 
 go 1.13
 
-require github.com/klauspost/cpuid/v2 v2.0.4
+require github.com/klauspost/cpuid/v2 v2.0.6

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,2 @@
-github.com/klauspost/cpuid/v2 v2.0.3 h1:DNljyrHyxlkk8139OXIAAauCwV8eQGDD6Z8YqnDXdZw=
-github.com/klauspost/cpuid/v2 v2.0.3/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
-github.com/klauspost/cpuid/v2 v2.0.4 h1:g0I61F2K2DjRHz1cnxlkNSBIaePVoJIjjnHui8QHbiw=
-github.com/klauspost/cpuid/v2 v2.0.4/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
+github.com/klauspost/cpuid/v2 v2.0.6 h1:dQ5ueTiftKxp0gyjKSx5+8BtPWkyQbd95m8Gys/RarI=
+github.com/klauspost/cpuid/v2 v2.0.6/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=


### PR DESCRIPTION
Upgrade github.com/klauspost/cpuid/v2@v2.0.6 for support darwin AVX512.

run:
```
$ go mod edit -require=github.com/klauspost/cpuid/v2@latest
$ rm -f go.sum; go1.16.3 mod tidy
```